### PR TITLE
Basic types

### DIFF
--- a/shared/ssz/decode/basic_types.go
+++ b/shared/ssz/decode/basic_types.go
@@ -11,6 +11,14 @@ func UnmarshalUint8(in byte) uint8 {
 	return in
 }
 
+func UnmarshalUint16(in []byte) (uint16, error) {
+	if len(in) != 2 {
+		return uint16(0), errors.New("length other than 2 not allowed")
+	}
+
+	return binary.LittleEndian.Uint16(in), nil
+}
+
 func UnmarshalUint32(in []byte) (uint32, error) {
 	if len(in) != 4 {
 		return uint32(0), errors.New("length other than 4 not allowed")

--- a/shared/ssz/decode/basic_types.go
+++ b/shared/ssz/decode/basic_types.go
@@ -3,6 +3,8 @@ package decode
 import (
 	"encoding/binary"
 	"errors"
+
+	uint128 "github.com/cockroachdb/cockroach/pkg/util/uint128"
 )
 
 // TODO work on error messages
@@ -33,6 +35,17 @@ func UnmarshalUint64(in []byte) (uint64, error) {
 	}
 
 	return binary.LittleEndian.Uint64(in), nil
+}
+
+func UnmarshalUint128(in []byte) (uint128.Uint128, error) { // TODO i might be unmarshaling it in the wrong order
+	if len(in) != 16 {
+		return uint128.Uint128{}, errors.New("length other than 16 not allowed")
+	}
+
+	hi := binary.LittleEndian.Uint64(in[:8])
+	lo := binary.LittleEndian.Uint64(in[8:])
+
+	return uint128.Uint128{hi, lo}, nil
 }
 
 func UnmarshalBoolean(in byte) (bool, error) { // TODO is this necessary?

--- a/shared/ssz/decode/basic_types.go
+++ b/shared/ssz/decode/basic_types.go
@@ -3,8 +3,6 @@ package decode
 import (
 	"encoding/binary"
 	"errors"
-
-	uint128 "github.com/cockroachdb/cockroach/pkg/util/uint128"
 )
 
 // TODO work on error messages
@@ -35,17 +33,6 @@ func UnmarshalUint64(in []byte) (uint64, error) {
 	}
 
 	return binary.LittleEndian.Uint64(in), nil
-}
-
-func UnmarshalUint128(in []byte) (uint128.Uint128, error) { // TODO i might be unmarshaling it in the wrong order
-	if len(in) != 16 {
-		return uint128.Uint128{}, errors.New("length other than 16 not allowed")
-	}
-
-	hi := binary.LittleEndian.Uint64(in[:8])
-	lo := binary.LittleEndian.Uint64(in[8:])
-
-	return uint128.Uint128{hi, lo}, nil
 }
 
 func UnmarshalBoolean(in byte) (bool, error) { // TODO is this necessary?

--- a/shared/ssz/decode/basic_types.go
+++ b/shared/ssz/decode/basic_types.go
@@ -1,0 +1,38 @@
+package decode
+
+import (
+	"encoding/binary"
+	"errors"
+)
+
+// TODO work on error messages
+
+func UnmarshalUint8(in byte) uint8 {
+	return in
+}
+
+func UnmarshalUint32(in []byte) (uint32, error) {
+	if len(in) != 4 {
+		return uint32(0), errors.New("length other than 4 not allowed")
+	}
+
+	return binary.LittleEndian.Uint32(in), nil
+}
+
+func UnmarshalUint64(in []byte) (uint64, error) {
+	if len(in) != 8 {
+		return uint64(0), errors.New("length other than 8 not allowed")
+	}
+
+	return binary.LittleEndian.Uint64(in), nil
+}
+
+func UnmarshalBoolean(in byte) (bool, error) { // TODO is this necessary?
+	if in == 1 {
+		return true, nil
+	} else if in == 0 {
+		return false, nil
+	}
+
+	return false, errors.New("input is neither 0 nor 1")
+}

--- a/shared/ssz/decode/basic_types_test.go
+++ b/shared/ssz/decode/basic_types_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestUnmarshalUint8(t *testing.T) {
 	var tests = []struct {
-		in byte
+		in       byte
 		expected uint8
 	}{
 		{in: byte(8), expected: uint8(8)},
@@ -26,7 +26,7 @@ func TestUnmarshalUint8(t *testing.T) {
 
 func TestUnmarshalUint16_Successful(t *testing.T) {
 	var tests = []struct {
-		in []byte
+		in       []byte
 		expected uint16
 	}{
 		{in: []byte{8, 0}, expected: uint16(8)},
@@ -63,7 +63,7 @@ func TestUnmarshalUint16_Unsuccessful(t *testing.T) {
 
 func TestUnmarshalUint32_Successful(t *testing.T) {
 	var tests = []struct {
-		in []byte
+		in       []byte
 		expected uint32
 	}{
 		{in: []byte{8, 0, 0, 0}, expected: uint32(8)},
@@ -100,7 +100,7 @@ func TestUnmarshalUint32_Unsuccessful(t *testing.T) {
 
 func TestUnmarshalUint64_Successful(t *testing.T) {
 	var tests = []struct {
-		in []byte
+		in       []byte
 		expected uint64
 	}{
 		{in: []byte{8, 0, 0, 0, 0, 0, 0, 0}, expected: uint64(8)},
@@ -137,7 +137,7 @@ func TestUnmarshalUint64_Unsuccessful(t *testing.T) {
 
 func TestUnmarshalBoolean_Successful(t *testing.T) {
 	var tests = []struct {
-		in byte
+		in       byte
 		expected bool
 	}{
 		{in: byte(1), expected: true},

--- a/shared/ssz/decode/basic_types_test.go
+++ b/shared/ssz/decode/basic_types_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	uint128 "github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,7 +60,7 @@ func TestUnmarshalUint32(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			actual, err := UnmarshalUint32(tt.in)
 			if err != nil {
-				t.Error("UnmarshalUint16 returned error", err)
+				t.Error("UnmarshalUint32 returned error", err)
 			}
 			assert.Equal(t, tt.expected, actual)
 		})
@@ -86,3 +87,35 @@ func TestUnmarshalUint64(t *testing.T) {
 		})
 	}
 }
+
+func TestUnmarshalUint128(t *testing.T) {
+	var tests = []struct {
+		in []byte
+		expected uint128.Uint128
+	}{
+		{
+			in: []byte{8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			expected: uint128.Uint128{8, 0},
+		},
+		{
+				in: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				expected: uint128.Uint128{0, 0},
+		},
+		{
+					in: []byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+					expected: uint128.Uint128{Hi: 18446744073709551615, Lo: 18446744073709551615},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			actual, err := UnmarshalUint128(tt.in)
+			if err != nil {
+				t.Error("UnmarshalUint128 returned error", err)
+			}
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+

--- a/shared/ssz/decode/basic_types_test.go
+++ b/shared/ssz/decode/basic_types_test.go
@@ -1,0 +1,88 @@
+package decode
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalUint8(t *testing.T) {
+	var tests = []struct {
+		in byte
+		expected uint8
+	}{
+		{in: byte(8), expected: uint8(8)},
+		{in: byte(0), expected: uint8(0)},
+		{in: byte(255), expected: uint8(255)},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tt.expected, UnmarshalUint8(tt.in))
+		})
+	}
+}
+
+func TestUnmarshalUint16(t *testing.T) {
+	var tests = []struct {
+		in []byte
+		expected uint16
+	}{
+		{in: []byte{8, 0}, expected: uint16(8)},
+		{in: []byte{0, 0}, expected: uint16(0)},
+		{in: []byte{255, 255}, expected: uint16(65535)},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			actual, err := UnmarshalUint16(tt.in)
+			if err != nil {
+				t.Error("UnmarshalUint16 returned error", err)
+			}
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestUnmarshalUint32(t *testing.T) {
+	var tests = []struct {
+		in []byte
+		expected uint32
+	}{
+		{in: []byte{8, 0, 0, 0}, expected: uint32(8)},
+		{in: []byte{0, 0, 0, 0}, expected: uint32(0)},
+		{in: []byte{255, 255, 255, 255}, expected: uint32(4294967295)},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			actual, err := UnmarshalUint32(tt.in)
+			if err != nil {
+				t.Error("UnmarshalUint16 returned error", err)
+			}
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestUnmarshalUint64(t *testing.T) {
+	var tests = []struct {
+		in []byte
+		expected uint64
+	}{
+		{in: []byte{8, 0, 0, 0, 0, 0, 0, 0}, expected: uint64(8)},
+		{in: []byte{0, 0, 0, 0, 0, 0, 0, 0}, expected: uint64(0)},
+		{in: []byte{255, 255, 255, 255, 255, 255, 255, 255}, expected: uint64(18446744073709551615)},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			actual, err := UnmarshalUint64(tt.in)
+			if err != nil {
+				t.Error("UnmarshalUint64 returned error", err)
+			}
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/shared/ssz/decode/basic_types_test.go
+++ b/shared/ssz/decode/basic_types_test.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"testing"
 
-	uint128 "github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -87,35 +86,3 @@ func TestUnmarshalUint64(t *testing.T) {
 		})
 	}
 }
-
-func TestUnmarshalUint128(t *testing.T) {
-	var tests = []struct {
-		in []byte
-		expected uint128.Uint128
-	}{
-		{
-			in: []byte{8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			expected: uint128.Uint128{8, 0},
-		},
-		{
-				in: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-				expected: uint128.Uint128{0, 0},
-		},
-		{
-					in: []byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
-					expected: uint128.Uint128{Hi: 18446744073709551615, Lo: 18446744073709551615},
-		},
-	}
-
-	for i, tt := range tests {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			actual, err := UnmarshalUint128(tt.in)
-			if err != nil {
-				t.Error("UnmarshalUint128 returned error", err)
-			}
-			assert.Equal(t, tt.expected, actual)
-		})
-	}
-}
-
-

--- a/shared/ssz/decode/basic_types_test.go
+++ b/shared/ssz/decode/basic_types_test.go
@@ -24,7 +24,7 @@ func TestUnmarshalUint8(t *testing.T) {
 	}
 }
 
-func TestUnmarshalUint16(t *testing.T) {
+func TestUnmarshalUint16_Successful(t *testing.T) {
 	var tests = []struct {
 		in []byte
 		expected uint16
@@ -45,7 +45,23 @@ func TestUnmarshalUint16(t *testing.T) {
 	}
 }
 
-func TestUnmarshalUint32(t *testing.T) {
+func TestUnmarshalUint16_Unsuccessful(t *testing.T) {
+	var tests = []struct {
+		in []byte
+	}{
+		{in: []byte{8, 0, 0, 0, 0, 0, 0, 0, 0}},
+		{in: []byte{255}},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			_, err := UnmarshalUint16(tt.in)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestUnmarshalUint32_Successful(t *testing.T) {
 	var tests = []struct {
 		in []byte
 		expected uint32
@@ -66,7 +82,23 @@ func TestUnmarshalUint32(t *testing.T) {
 	}
 }
 
-func TestUnmarshalUint64(t *testing.T) {
+func TestUnmarshalUint32_Unsuccessful(t *testing.T) {
+	var tests = []struct {
+		in []byte
+	}{
+		{in: []byte{8, 0, 0, 0, 0, 0, 0, 0, 0}},
+		{in: []byte{255, 255, 255}},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			_, err := UnmarshalUint32(tt.in)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestUnmarshalUint64_Successful(t *testing.T) {
 	var tests = []struct {
 		in []byte
 		expected uint64
@@ -83,6 +115,58 @@ func TestUnmarshalUint64(t *testing.T) {
 				t.Error("UnmarshalUint64 returned error", err)
 			}
 			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestUnmarshalUint64_Unsuccessful(t *testing.T) {
+	var tests = []struct {
+		in []byte
+	}{
+		{in: []byte{8, 0, 0, 0, 0, 0, 0, 0, 0}},
+		{in: []byte{255, 255, 255, 255, 255, 255}},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			_, err := UnmarshalUint64(tt.in)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestUnmarshalBoolean_Successful(t *testing.T) {
+	var tests = []struct {
+		in byte
+		expected bool
+	}{
+		{in: byte(1), expected: true},
+		{in: byte(0), expected: false},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			actual, err := UnmarshalBoolean(tt.in)
+			if err != nil {
+				t.Error(err)
+			}
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestUnmarshalBoolean_Unsuccessful(t *testing.T) {
+	var tests = []struct {
+		in byte
+	}{
+		{in: byte(2)},
+		{in: byte(255)},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			_, err := UnmarshalBoolean(tt.in)
+			assert.Error(t, err)
 		})
 	}
 }

--- a/shared/ssz/encode/basic_types.go
+++ b/shared/ssz/encode/basic_types.go
@@ -2,9 +2,6 @@ package encode
 
 import (
 	"encoding/binary"
-
-	"github.com/cockroachdb/cockroach/pkg/util/uint128"
-	"github.com/holiman/uint256"
 )
 
 func MarshalUint8(in uint8) byte {
@@ -31,23 +28,6 @@ func MarshalUint64(in uint64) []byte {
 	out := make([]byte, 8)
 
 	binary.LittleEndian.PutUint64(out, in)
-
-	return out
-}
-
-func MarshalUint128(in uint128.Uint128) []byte { // TODO i might be marshaling it in the wrong order
-	out := make([]byte, 16)
-
-	binary.LittleEndian.PutUint64(out[:8], in.Hi)
-	binary.LittleEndian.PutUint64(out[8:], in.Lo)
-
-	return out
-}
-
-func MarshalUint256(in uint256.Int) []byte {
-	out := make([]byte, 32)
-
-	in.WriteToSlice(out)
 
 	return out
 }

--- a/shared/ssz/encode/basic_types.go
+++ b/shared/ssz/encode/basic_types.go
@@ -1,0 +1,39 @@
+package encode
+
+import "encoding/binary"
+
+func MarshalUint8(in uint8) byte {
+	return byte(in)
+}
+
+func MarshalUint16(in uint16) []byte {
+	out := make([]byte, 2)
+
+	binary.LittleEndian.PutUint16(out, in)
+
+	return out
+}
+
+func MarshalUint32(in uint32) []byte {
+	out := make([]byte, 4)
+
+	binary.LittleEndian.PutUint32(out, in)
+
+	return out
+}
+
+func MarshalUint64(in uint64) []byte {
+	out := make([]byte, 8)
+
+	binary.LittleEndian.PutUint64(out, in)
+
+	return out
+}
+
+func MarshalBoolean(in bool) byte { // TODO is this necessary?
+	if in {
+		return 1
+	}
+
+	return 0
+}

--- a/shared/ssz/encode/basic_types.go
+++ b/shared/ssz/encode/basic_types.go
@@ -1,6 +1,10 @@
 package encode
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+
+	"github.com/cockroachdb/cockroach/pkg/util/uint128"
+)
 
 func MarshalUint8(in uint8) byte {
 	return byte(in)
@@ -26,6 +30,15 @@ func MarshalUint64(in uint64) []byte {
 	out := make([]byte, 8)
 
 	binary.LittleEndian.PutUint64(out, in)
+
+	return out
+}
+
+func MarshalUint128(in uint128.Uint128) []byte { // TODO i might be marshaling it in the wrong order
+	out := make([]byte, 16)
+
+	binary.LittleEndian.PutUint64(out[:8], in.Hi)
+	binary.LittleEndian.PutUint64(out[8:], in.Lo)
 
 	return out
 }

--- a/shared/ssz/encode/basic_types.go
+++ b/shared/ssz/encode/basic_types.go
@@ -45,12 +45,11 @@ func MarshalUint128(in uint128.Uint128) []byte { // TODO i might be marshaling i
 }
 
 func MarshalUint256(in uint256.Int) [32]byte {
-	return in.Bytes32()
-	//out := make([]byte, 32)
-	//
-	//in.WriteToSlice(out)
-	//
-	//return out
+	out := make([]byte, 32)
+
+	in.WriteToSlice(out)
+
+	return out
 }
 
 func MarshalBoolean(in bool) byte { // TODO is this necessary?

--- a/shared/ssz/encode/basic_types.go
+++ b/shared/ssz/encode/basic_types.go
@@ -44,12 +44,13 @@ func MarshalUint128(in uint128.Uint128) []byte { // TODO i might be marshaling i
 	return out
 }
 
-func MarshalUint256(in uint256.Int) []byte {
-	out := make([]byte, 32)
-
-	in.WriteToSlice(out)
-
-	return out
+func MarshalUint256(in uint256.Int) [32]byte {
+	return in.Bytes32()
+	//out := make([]byte, 32)
+	//
+	//in.WriteToSlice(out)
+	//
+	//return out
 }
 
 func MarshalBoolean(in bool) byte { // TODO is this necessary?

--- a/shared/ssz/encode/basic_types.go
+++ b/shared/ssz/encode/basic_types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
+	"github.com/holiman/uint256"
 )
 
 func MarshalUint8(in uint8) byte {
@@ -39,6 +40,14 @@ func MarshalUint128(in uint128.Uint128) []byte { // TODO i might be marshaling i
 
 	binary.LittleEndian.PutUint64(out[:8], in.Hi)
 	binary.LittleEndian.PutUint64(out[8:], in.Lo)
+
+	return out
+}
+
+func MarshalUint256(in uint256.Int) []byte {
+	out := make([]byte, 32)
+
+	in.WriteToSlice(out)
 
 	return out
 }

--- a/shared/ssz/encode/basic_types.go
+++ b/shared/ssz/encode/basic_types.go
@@ -44,7 +44,7 @@ func MarshalUint128(in uint128.Uint128) []byte { // TODO i might be marshaling i
 	return out
 }
 
-func MarshalUint256(in uint256.Int) [32]byte {
+func MarshalUint256(in uint256.Int) []byte {
 	out := make([]byte, 32)
 
 	in.WriteToSlice(out)

--- a/shared/ssz/encode/basic_types_test.go
+++ b/shared/ssz/encode/basic_types_test.go
@@ -111,8 +111,8 @@ func TestMarshalUint256(t *testing.T) {
 		expected []byte
 	}{
 		{
-			in: [4]uint64{uint64(0), uint64(0), uint64(0), uint64(8)},
-			expected: []byte{8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			in: [4]uint64{uint64(0), uint64(0), uint64(0), uint64(1)},
+			expected: []byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		},
 		{
 			in: [4]uint64{uint64(0), uint64(0), uint64(0), uint64(0)},

--- a/shared/ssz/encode/basic_types_test.go
+++ b/shared/ssz/encode/basic_types_test.go
@@ -1,0 +1,76 @@
+package encode
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalUint8(t *testing.T) {
+	var tests = []struct {
+		in uint8
+		expected byte
+	}{
+		{in: uint8(8), expected: byte(8)},
+		{in: uint8(0), expected: byte(0)},
+		{in: uint8(255), expected: byte(255)},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tt.expected, MarshalUint8(tt.in))
+		})
+	}
+}
+
+func TestMarshalUint16(t *testing.T) {
+	var tests = []struct {
+		in uint16
+		expected []byte
+	}{
+		{in: uint16(8), expected: []byte{8, 0}},
+		{in: uint16(0), expected: []byte{0, 0}},
+		{in: uint16(65535), expected: []byte{255, 255}},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tt.expected, MarshalUint16(tt.in))
+		})
+	}
+}
+
+func TestMarshalUint32(t *testing.T) {
+	var tests = []struct {
+		in uint32
+		expected []byte
+	}{
+		{in: uint32(8), expected: []byte{8, 0, 0, 0}},
+		{in: uint32(0), expected: []byte{0, 0, 0, 0}},
+		{in: uint32(4294967295), expected: []byte{255, 255, 255, 255}},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tt.expected, MarshalUint32(tt.in))
+		})
+	}
+}
+
+func TestMarshalUint64(t *testing.T) {
+	var tests = []struct {
+		in uint64
+		expected []byte
+	}{
+		{in: uint64(8), expected: []byte{8, 0, 0, 0, 0, 0, 0, 0}},
+		{in: uint64(0), expected: []byte{0, 0, 0, 0, 0, 0, 0, 0}},
+		{in: uint64(18446744073709551615), expected: []byte{255, 255, 255, 255, 255, 255, 255, 255}},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tt.expected, MarshalUint64(tt.in))
+		})
+	}
+}

--- a/shared/ssz/encode/basic_types_test.go
+++ b/shared/ssz/encode/basic_types_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -74,3 +75,31 @@ func TestMarshalUint64(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalUint128(t *testing.T) {
+	var tests = []struct {
+		in uint128.Uint128
+		expected []byte
+	}{
+		{
+			in: uint128.Uint128{8, 0},
+			expected: []byte{8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			in: uint128.Uint128{0, 0},
+			expected: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			in: uint128.Uint128{18446744073709551615, 18446744073709551615},
+			expected: []byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tt.expected, MarshalUint128(tt.in))
+		})
+	}
+}
+
+

--- a/shared/ssz/encode/basic_types_test.go
+++ b/shared/ssz/encode/basic_types_test.go
@@ -111,7 +111,7 @@ func TestMarshalUint256(t *testing.T) {
 		expected []byte
 	}{
 		{
-			in: [4]uint64{uint64(8), uint64(0), uint64(0), uint64(0)},
+			in: [4]uint64{uint64(0), uint64(0), uint64(0), uint64(8)},
 			expected: []byte{8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		},
 		{

--- a/shared/ssz/encode/basic_types_test.go
+++ b/shared/ssz/encode/basic_types_test.go
@@ -1,13 +1,9 @@
 package encode
 
 import (
-	"encoding/binary"
-	"fmt"
 	"strconv"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/util/uint128"
-	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,62 +74,3 @@ func TestMarshalUint64(t *testing.T) {
 		})
 	}
 }
-
-func TestMarshalUint128(t *testing.T) {
-	var tests = []struct {
-		in uint128.Uint128
-		expected []byte
-	}{
-		{
-			in: uint128.Uint128{8, 0},
-			expected: []byte{8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		},
-		{
-			in: uint128.Uint128{0, 0},
-			expected: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		},
-		{
-			in: uint128.Uint128{18446744073709551615, 18446744073709551615},
-			expected: []byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
-		},
-	}
-
-	for i, tt := range tests {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			assert.Equal(t, tt.expected, MarshalUint128(tt.in))
-		})
-	}
-}
-
-func TestMarshalUint256(t *testing.T) {
-	var tests = []struct {
-		in uint256.Int
-		expected []byte
-	}{
-		{
-			in: [4]uint64{uint64(0), uint64(0), uint64(0), uint64(1)},
-			expected: []byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		},
-		{
-			in: [4]uint64{uint64(0), uint64(0), uint64(0), uint64(0)},
-			expected: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		},
-		{
-			in: [4]uint64{uint64(18446744073709551615), uint64(18446744073709551615), uint64(18446744073709551615), uint64(18446744073709551615)},
-			expected: []byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
-		},
-	}
-
-	for i, tt := range tests {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			fmt.Println(MarshalUint256(tt.in))
-			blah := uint64(8)
-			buf := make([]byte, 8)
-			binary.LittleEndian.PutUint64(buf, blah)
-			fmt.Println(buf)
-			assert.Equal(t, tt.expected, MarshalUint256(tt.in))
-		})
-	}
-}
-
-

--- a/shared/ssz/encode/basic_types_test.go
+++ b/shared/ssz/encode/basic_types_test.go
@@ -74,3 +74,19 @@ func TestMarshalUint64(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalBoolean(t *testing.T) {
+	var tests = []struct {
+		in bool
+		expected byte
+	}{
+		{in: true, expected: byte(1)},
+		{in: false, expected: byte(0)},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tt.expected, MarshalBoolean(tt.in))
+		})
+	}
+}

--- a/shared/ssz/encode/basic_types_test.go
+++ b/shared/ssz/encode/basic_types_test.go
@@ -1,10 +1,12 @@
 package encode
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -98,6 +100,33 @@ func TestMarshalUint128(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			assert.Equal(t, tt.expected, MarshalUint128(tt.in))
+		})
+	}
+}
+
+func TestMarshalUint256(t *testing.T) {
+	var tests = []struct {
+		in uint256.Int
+		expected []byte
+	}{
+		{
+			in: [4]uint64{uint64(8), uint64(0), uint64(0), uint64(0)},
+			expected: []byte{8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			in: [4]uint64{uint64(0), uint64(0), uint64(0), uint64(0)},
+			expected: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			in: [4]uint64{uint64(18446744073709551615), uint64(18446744073709551615), uint64(18446744073709551615), uint64(18446744073709551615)},
+			expected: []byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			fmt.Println(MarshalUint256(tt.in))
+			assert.Equal(t, tt.expected, MarshalUint256(tt.in))
 		})
 	}
 }

--- a/shared/ssz/encode/basic_types_test.go
+++ b/shared/ssz/encode/basic_types_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMarshalUint8(t *testing.T) {
 	var tests = []struct {
-		in uint8
+		in       uint8
 		expected byte
 	}{
 		{in: uint8(8), expected: byte(8)},
@@ -26,7 +26,7 @@ func TestMarshalUint8(t *testing.T) {
 
 func TestMarshalUint16(t *testing.T) {
 	var tests = []struct {
-		in uint16
+		in       uint16
 		expected []byte
 	}{
 		{in: uint16(8), expected: []byte{8, 0}},
@@ -43,7 +43,7 @@ func TestMarshalUint16(t *testing.T) {
 
 func TestMarshalUint32(t *testing.T) {
 	var tests = []struct {
-		in uint32
+		in       uint32
 		expected []byte
 	}{
 		{in: uint32(8), expected: []byte{8, 0, 0, 0}},
@@ -60,7 +60,7 @@ func TestMarshalUint32(t *testing.T) {
 
 func TestMarshalUint64(t *testing.T) {
 	var tests = []struct {
-		in uint64
+		in       uint64
 		expected []byte
 	}{
 		{in: uint64(8), expected: []byte{8, 0, 0, 0, 0, 0, 0, 0}},
@@ -77,7 +77,7 @@ func TestMarshalUint64(t *testing.T) {
 
 func TestMarshalBoolean(t *testing.T) {
 	var tests = []struct {
-		in bool
+		in       bool
 		expected byte
 	}{
 		{in: true, expected: byte(1)},

--- a/shared/ssz/encode/basic_types_test.go
+++ b/shared/ssz/encode/basic_types_test.go
@@ -1,6 +1,7 @@
 package encode
 
 import (
+	"encoding/binary"
 	"fmt"
 	"strconv"
 	"testing"
@@ -126,6 +127,10 @@ func TestMarshalUint256(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			fmt.Println(MarshalUint256(tt.in))
+			blah := uint64(8)
+			buf := make([]byte, 8)
+			binary.LittleEndian.PutUint64(buf, blah)
+			fmt.Println(buf)
 			assert.Equal(t, tt.expected, MarshalUint256(tt.in))
 		})
 	}


### PR DESCRIPTION
Adds support for encoding and decoding the following basic types: 
* uint(8-64)
* bool

Also provides a directory hierarchy for organization of the ssz component for prysm.